### PR TITLE
Expand README to contain installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 This repository will allow you to create a monitoring namespace in a MoJ Cloud Platform cluster. It will also contain the neseccary values to perform an installation of Prometheus-Operator and Kube-Prometheus. 
 
-  - [Pre-reqs](#prereq)
-  - [Creating a monitoring namespace](#installation)
-  - [Installing Prometheus-Operator](#output-example)
-  - [Installng Kube-Prometheus](#usage)
-  - [Exposing the port](#features-and-advantages-of-this-project)  
-  - [How to tear it all down](#am-i-missing-some-essential-feature)
-  - [Contributing](#contributing)
+  - [Pre-reqs](#pre-reqs)
+  - [Creating a monitoring namespace](#creating-a-monitoring-namespace)
+  - [Installing Prometheus-Operator](#installing-prometheus-operator)
+  - [Installng Kube-Prometheus](#installing-kube-prometheus)
+  - [Exposing the port](#exposing-the-port)
+  - [How to tear it all down](#how-to-tear-it-all-down)
 
 ```
 TL;DR

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Cloud-Platform Prometheus
-==================
+# Cloud Platform Prometheus
 
 This repository will allow you to create a monitoring namespace in a MoJ Cloud Platform cluster. It will also contain the neseccary values to perform an installation of Prometheus-Operator and Kube-Prometheus. 
 
@@ -13,7 +12,7 @@ This repository will allow you to create a monitoring namespace in a MoJ Cloud P
 
 ```
 TL;DR
-# Copy dir to your namespace in the cloud-platform-environments repository.
+# Copy ./monitoring dir to the namespace dir in the cloud-platform-environments repository.
 
 # Add CoreOS Helm repo
 $ helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
@@ -32,11 +31,41 @@ $ kubectl port-forward -n monitoring prometheus-kube-prometheus-0 9090
 It is assumed that you have authenticated to an MoJ Cloud-Platform Cluster and you have Helm installed and configured.
 
 ## Creating a monitoring namespace
-
+To create a monitoring namespace you will need to copy the `./monitoring` directory in this repository to a branch in the [Cloud-Plarform-Environments](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces). Once this branch has been reviewed and merged to `master` a pipeline is kicked off, creating a namespace called `monitoring`. 
 
 ## Installing Prometheus-Operator
-## Installing Kube-Prometheus
-## Exposing the port
-## How to tear it all down
+> The mission of the Prometheus Operator is to make running Prometheus
+> on top of Kubernetes as easy as possible, while preserving
+> configurability as well as making the configuration Kubernetes native.
+> [https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html](https://coreos.com/operators/prometheus/docs/latest/user-guides/getting-started.html)
 
-Necessary configuration to initiate a monitoring namespace in an MoJ Cloud Platform. 
+The Prometheus Operator provides easy monitoring for Kubernetes services and deployments besides managing Prometheus, Alertmanager and Grafana configuration.
+
+To install Prometheus Operator, run:
+```
+$ helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
+
+$ helm install coreos/prometheus-operator --name prometheus-operator --namespace monitoring -f ./monitoring/helm/prometheus-operator/values.yaml
+```
+And then confirm the operator is running in the monitoring namspace:
+```
+$ kubectl get pods -n monitoring
+```
+
+## Installing Kube-Prometheus
+Prometheus is an open source toolkit to monitor and alert, inspired by Google Borg Monitor. It was previously developed by SoundCloud and afterwards donated to the CNCF.
+
+To install kube-prometheus, run:
+```
+$ helm install coreos/kube-prometheus --name kube-prometheus --set global.rbacEnable=true --namespace monitoring -f ./monitoring/helm/kube-prometheus/values.yaml
+```
+## Exposing the port
+Due to a lack of auth options, we've decided to use port forwarding to prevent unauthorised access. Forward the Prometheus server to your machine so you can take a better look at the dashboard by opening http://localhost:9090.
+```
+$ kubectl port-forward -n monitoring prometheus-kube-prometheus-0 9090
+```
+## How to tear it all down
+If you need to uninstall kube-prometheus and the prometheus-operator then you will simple need to run the following:
+```
+$ helm del --purge kube-prometheus && helm del --purge prometheus-operator
+```


### PR DESCRIPTION
connects to https://github.com/ministryofjustice/cloud-platform/issues/144

**WHAT**
Expanded the README to contain instructions to install Prometheus Operator and Kube Prometheus, followed by 'how to expose a port'.
**WHY**
As per https://github.com/ministryofjustice/cloud-platform/issues/144. Created documentation to allow a Cloud Platform team member to install Prometheus on a blank cluster. 
