### PR TITLE
Added PagerDuty and Slack integrations

### DIFF
--- a/highErrors.ALERT
+++ b/highErrors.ALERT
@@ -1,0 +1,10 @@
+groups:
+- name: example
+  rules:
+  - alert: HighErrorRate
+    expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+    for: 10m
+    labels:
+      severity: page
+    annotations:
+      summary: High request latency

--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -35,7 +35,7 @@ alertmanager:
         receiver: pager-duty-high-priority
       - match: 
           severity: warning
-        receiver: pager-duty-low-priority
+        receiver: slack-low-priority
     receivers:
     - name: 'null'
     # Add PagerDuty key to allow integration with a PD service. 
@@ -43,10 +43,12 @@ alertmanager:
       pagerduty_configs:
       - service_key: "$KEY"
     # Add Slack webhook API URL and channel for integration with slack.
-    - name: 'pager-duty-low-priority'
+    - name: 'slack-low-priority'
       slack_configs:
       - api_url: "$WEBHOOK_URL"
         channel: "#general"
+        text: "<!channel> \ndescription: {{ .CommonAnnotations.description }}\nsummary: {{ .CommonAnnotations.summary }}"
+        send_resolved: True
 
   ## Alertmanager template files to include
   #

--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -30,8 +30,28 @@ alertmanager:
       - match:
           alertname: DeadMansSwitch
         receiver: 'null'
+      - match: 
+          severity: critical
+        receiver: pager-duty-high-priority
+      - match: 
+          severity: warning
+        receiver: pager-duty-low-priority
     receivers:
     - name: 'null'
+    # Add PagerDuty key to allow integration with a PD service. 
+    - name: 'pager-duty-high-priority'
+      pagerduty_configs:
+      - service_key: "$KEY"
+    # Add Slack webhook API URL and channel for integration with slack.
+    - name: 'pager-duty-low-priority'
+      slack_configs:
+      - api_url: "$WEBHOOK_URL"
+        channel: "#general"
+
+  ## Alertmanager template files to include
+  #
+  templateFiles: {}
+
 
   ## External URL at which Alertmanager will be reachable
   ##


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/152

**WHAT**

A change to the values.yaml for kube-prometheus allowing us to create a PagerDuty and Slack receiver.  
Created alert matches on the severity and subsequent route to take. 

**WHY**

To enable us to set routes for certain severity i.e. critical goes to PD and warning hits slack. 

**NOTES**

Documentation will specify how to add webhook data. 