### PR TITLE
Custom Alert Instructions - Node Disk Space Low

### DIFF
--- a/runbook/Node-Disk-Space-Low.md
+++ b/runbook/Node-Disk-Space-Low.md
@@ -1,0 +1,20 @@
+# Node-Disk-Space-Low
+
+## Alarm
+```
+Node-Disk-Space-Low
+```
+
+## Observation
+Run the following command to confirm disk shortage on a node:
+`kubectl describe nodes`
+
+You are looking for the boolean condition of:
+`OutOfDiskSpace`
+
+## Action
+Please read the documentation from [Kubernetes](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#changing-the-root-volume-size-or-type) regarding best possible actions.
+
+[Changing the root volume size or type](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#changing-the-root-volume-size-or-type)
+[Resize an instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#resize-an-instance-group)
+[Change the instance type in an instance group](https://github.com/kubernetes/kops/blob/master/docs/instance_groups.md#change-the-instance-type-in-an-instance-group)


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/157

**WHAT**
First stab at instructions for how to deal with a triggered alert named `node-disk-space-low`.

**WHY**
As part of https://github.com/ministryofjustice/cloud-platform/issues/157 I have to add instructions on how to deal with this alarm. I've decided to do this in a mini runbook to allow us to build a repertoire.
