### PR TITLE
Expose the prometheus UI and add oauth proxy

### DIFF
--- a/monitoring/helm/kube-prometheus/ingress.yaml
+++ b/monitoring/helm/kube-prometheus/ingress.yaml
@@ -1,9 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: monitoring
+  name: monitoring-auth-oauth2
+  namespace: monitoring
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    "nginx.ingress.kubernetes.io/auth-url": "https://$host/oauth2/auth"
+    "nginx.ingress.kubernetes.io/auth-signin": "https://$host/oauth2/start"
 spec:
   rules:
   - host: prometheus.apps.cloud-platform-test-1.k8s.integration.dsd.io
@@ -13,3 +16,23 @@ spec:
           serviceName: kube-prometheus
           servicePort: 9090
         path: /
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+  namespace: monitoring
+spec:
+  rules:
+  - host: prometheus.apps.cloud-platform-test-1.k8s.integration.dsd.io
+    http:
+      paths:
+      - backend:
+          serviceName: oauth2-proxy
+          servicePort: 4180
+        path: /oauth2
+  tls:
+  - hosts:
+    - prometheus.apps.cloud-platform-test-1.k8s.integration.dsd.io

--- a/monitoring/helm/kube-prometheus/ingress.yaml
+++ b/monitoring/helm/kube-prometheus/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: monitoring
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: prometheus.apps.cloud-platform-test-1.k8s.integration.dsd.io
+    http:
+      paths:
+      - backend:
+          serviceName: kube-prometheus
+          servicePort: 9090
+        path: /

--- a/monitoring/helm/kube-prometheus/oauth2-proxy.yaml
+++ b/monitoring/helm/kube-prometheus/oauth2-proxy.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: oauth2-proxy
+    spec:
+      # Populate the arguments below. To generate a cookie-secret use: "python -c 'import os,base64; print base64.b64encode(os.urandom(16))'"
+      containers:
+      - args:
+        - --provider=github
+        - --github-org=<org_name>
+        - --github-team=<team_name>
+        - --email-domain=*
+        - --upstream=file:///dev/null
+        - --http-address=0.0.0.0:4180
+        - --client-id=<GitHub_Client_ID>
+        - --client-secret=<GitHub_Client_Secret>
+        - --cookie-secret=<shared_secret>
+        - --redirect-url=<https://host.cluster.example.io/oauth2>
+        # Register a new application
+        # https://github.com/settings/applications/new
+        image: docker.io/machinedata/oauth2_proxy:latest
+        imagePullPolicy: Always
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+  namespace: monitoring
+spec:
+  ports:
+  - name: http
+    port: 4180
+    protocol: TCP
+    targetPort: 4180
+  selector:
+    k8s-app: oauth2-proxy


### PR DESCRIPTION
**WHAT**
- Added ingress manifest to allow Prometheus to be accessed from the Internet. 
- Added oauth2 proxy deployment manifest to auth with GitHub oauth application.

**WHY** 
As part of https://github.com/ministryofjustice/cloud-platform/issues/161. This will allow members of the a specified GitHub access to the Prometheus UI. 

**NOTES**
This has been applied to the test-1 cluster and confirmed working using a privileged and non-privileged user. 