### PR TITLE
OIDC proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloud Platform Prometheus
 
-This repository will allow you to create a monitoring namespace in a MoJ Cloud Platform cluster. It will also contain the necessary values to perform an installation of Prometheus-Operator and Kube-Prometheus. 
+This repository will allow you to create a monitoring namespace in a MoJ Cloud Platform cluster. It will also contain the necessary values to perform an installation of Prometheus-Operator and Kube-Prometheus.
 
   - [Pre-reqs](#pre-reqs)
   - [Creating a monitoring namespace](#creating-a-monitoring-namespace)
@@ -12,7 +12,7 @@ This repository will allow you to create a monitoring namespace in a MoJ Cloud P
   - [Installing Exporter-Kubelets](#installing-exporter-kubelets)
   - [Exposing the port](#exposing-the-port)
   - [How to add an alert to Prometheus](#how-to-add-an-alert-to-prometheus)
-  - [How to expose Prometheus UI and add oauth proxy](#how-to-expose-prometheus-ui-and-add-oauth-proxy)
+  - [How to expose the web interfaces behind an OIDC proxy](#how-to-expose-the-web-interfaces-behind-an-oidc-proxy)
   - [Adding Pingdom Alerts to monitor Prometheus and Alermanager Externally](#adding-pingdom-alerts-to-monitor-prometheus-and-alermanager-externally)
   - [How to tear it all down](#how-to-tear-it-all-down)
 
@@ -40,7 +40,7 @@ $ kubectl port-forward -n monitoring alertmanager-kube-prometheus-0 9093
 It is assumed that you have authenticated to an MoJ Cloud-Platform Cluster and you have Helm installed and configured.
 
 ## Creating a monitoring namespace
-To create a monitoring namespace you will need to copy the `./monitoring` directory in this repository to a branch in the [Cloud-Plarform-Environments](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces). Once this branch has been reviewed and merged to `master` a pipeline is kicked off, creating a namespace called `monitoring`. 
+To create a monitoring namespace you will need to copy the `./monitoring` directory in this repository to a branch in the [Cloud-Plarform-Environments](https://github.com/ministryofjustice/cloud-platform-environments/tree/master/namespaces). Once this branch has been reviewed and merged to `master` a pipeline is kicked off, creating a namespace called `monitoring`.
 
 ## Installing Prometheus-Operator
 > The mission of the Prometheus Operator is to make running Prometheus
@@ -65,12 +65,12 @@ $ kubectl get pods -n monitoring
 Prometheus is an open source toolkit to monitor and alert, inspired by Google Borg Monitor. It was previously developed by SoundCloud and afterwards donated to the CNCF.
 
 To install kube-prometheus, run:
-```bash 
+```bash
 $ helm install coreos/kube-prometheus --name kube-prometheus --set global.rbacEnable=true --namespace monitoring -f ./monitoring/helm/kube-prometheus/values.yaml
 ```
 
 ## Installing AlertManager
-> The Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing   them to the correct receiver integration such as email or PagerDuty. It also takes care of silencing and inhibition of alerts - 
+> The Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing   them to the correct receiver integration such as email or PagerDuty. It also takes care of silencing and inhibition of alerts -
 > [https://prometheus.io/docs/alerting/alertmanager/](https://prometheus.io/docs/alerting/alertmanager/)
 
 AlertManager can be installed (using a sub-chart) as part of the installtion of Kube-Prometheus.
@@ -82,10 +82,10 @@ deployAlertManager: true
 ```
 ## Configuring AlertManager to send alerts to PagerDuty
 
-Make note of the `service_key:` key on the Kube-Prometheus `values.yaml` file. 
+Make note of the `service_key:` key on the Kube-Prometheus `values.yaml` file.
 
 ```yaml
-# Add PagerDuty key to allow integration with a PD service. 
+# Add PagerDuty key to allow integration with a PD service.
     - name: 'pager-duty-high-priority'
       pagerduty_configs:
       - service_key: "$KEY"
@@ -100,7 +100,7 @@ This is a quick guide on how to retrive your service key from PagerDuty by follo
 
 2) Go to the **Configuration** menu and select **Services**.
 
-3) On the Services page: 
+3) On the Services page:
 
     * If you are creating a new service for your integration, click **Add New Service**.
 
@@ -127,7 +127,7 @@ Slack intergration is enabled using the kube-prometheus values.yaml file:
         send_resolved: True
 ```
 
-Follow the [official slack documentation](https://api.slack.com/incoming-webhooks) to create the `api_url:` and fill in the `channel:` with the name of the slack channel that will recieve the notifications. 
+Follow the [official slack documentation](https://api.slack.com/incoming-webhooks) to create the `api_url:` and fill in the `channel:` with the name of the slack channel that will recieve the notifications.
 
 ## Installing Exporter-Kubelets
 Exporter-Kubelets is a simple service that enables container metrics to be scraped by prometheus.
@@ -180,7 +180,7 @@ spec:
 
 The example PrometheusRule always immediately triggers an alert, which is only for demonstration purposes. To validate that everything is working properly have a look at each of the Prometheus web UIs.
 
-The directory `./custom-alerts` contains the manifest files for applying rules to your Prometheus alarms. 
+The directory `./custom-alerts` contains the manifest files for applying rules to your Prometheus alarms.
 
 To see the current rules applied to your Prometheus instance, run:
 
@@ -278,7 +278,3 @@ If you need to uninstall kube-prometheus and the prometheus-operator then you wi
 ```bash
 $ helm del --purge kube-prometheus && helm del --purge prometheus-operator
 ```
-
-
-
-

--- a/monitoring/oidc-proxy-secret.yaml
+++ b/monitoring/oidc-proxy-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitoring-oidc
+  namespace: monitoring
+type: Opaque
+data:
+  # Populate the values below with the keys generated in the auth0 app.
+  # To generate a cookie-secret use: `head -c 32 /dev/null | base64 | base64`
+  client-id: AA==
+  client-secret: AA==
+  cookie-secret: AA==

--- a/monitoring/oidc-proxy.yaml
+++ b/monitoring/oidc-proxy.yaml
@@ -1,0 +1,207 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oidc-proxy-auth-script
+  namespace: monitoring
+data:
+  # this is based on the upstream authentication script with added bits to limit
+  # access to the webops team
+  # https://github.com/evry/docker-oidc-proxy/blob/master/nginx/lua/auth.lua
+  auth.lua: |
+    local opts = {
+        redirect_uri_path = os.getenv("OID_REDIRECT_PATH") or "/redirect_uri",
+        discovery = os.getenv("OID_DISCOVERY"),
+        client_id = os.getenv("OID_CLIENT_ID"),
+        client_secret = os.getenv("OID_CLIENT_SECRET"),
+        token_endpoint_auth_method = os.getenv("OIDC_AUTH_METHOD") or "client_secret_basic",
+        scope = os.getenv("OIDC_AUTH_SCOPE") or "openid",
+        iat_slack = 600,
+    }
+
+    -- call authenticate for OpenID Connect user authentication
+    local res, err, _target, session = require("resty.openidc").authenticate(opts)
+    if err then
+        ngx.log(ngx.DEBUG, tostring(err))
+        ngx.exit(ngx.HTTP_FORBIDDEN)
+    end
+
+    allowed = false
+    if res.id_token["https://k8s.integration.dsd.io/groups"] ~= nil then
+      for k, v in pairs(res.id_token["https://k8s.integration.dsd.io/groups"]) do
+          if v == "github:webops" then
+              allowed = true
+              break
+          end
+      end
+    end
+    if not allowed then
+      ngx.exit(ngx.HTTP_FORBIDDEN)
+    end
+
+    ngx.log(ngx.DEBUG, "Authentication successful, setting Auth header...")
+    ngx.req.set_header("Authorization", "Bearer "..session.data.enc_id_token)
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oidc-proxy-config
+  namespace: monitoring
+data:
+  # .common is based on the default proxy configuration of the image
+  # https://github.com/evry/docker-oidc-proxy/blob/master/nginx/conf/sites/proxy.conf
+  .common.conf: |
+    listen 80;
+
+    error_log /dev/stdout info;
+
+    large_client_header_buffers 8 64k;
+    client_header_buffer_size 64k;
+    set_by_lua $session_secret 'return os.getenv("OID_SESSION_SECRET")';
+    set_by_lua $session_check_ssi 'return os.getenv("OID_SESSION_CHECK_SSI")';
+    set_by_lua $session_name 'return os.getenv("OID_SESSION_NAME")';
+
+    location /favicon.ico {
+      return 404;
+    }
+
+    location /healthz {
+      return 201;
+    }
+
+    location / {
+      access_by_lua_file  lua/auth.lua;
+      proxy_set_header    Host $http_host;
+      proxy_pass          http://$upstream;
+    }
+
+    error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+        root html;
+    }
+
+  00-http.conf: |
+    server_names_hash_bucket_size 128;
+
+  10-proxy_prometheus.conf: |
+    upstream prometheus {
+        server kube-prometheus:9090;
+    }
+    server {
+        server_name [[PROMETHEUS_HOSTNAME]];
+        set $upstream prometheus;
+        include sites/.common.conf;
+    }
+
+  11-proxy_alertmanager.conf: |
+    upstream alertmanager {
+        server kube-prometheus-alertmanager:9093;
+    }
+    server {
+        server_name [[ALERTMANAGER_HOSTNAME]];
+        set $upstream alertmanager;
+        include sites/.common.conf;
+    }
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: oidc-proxy
+  namespace: monitoring
+spec:
+  rules:
+  - host: [[PROMETHEUS_HOSTNAME]]
+    http:
+      paths:
+      - backend:
+          serviceName: oidc-proxy
+          servicePort: 80
+      - path: /-/healthy
+        backend:
+          serviceName: kube-prometheus
+          servicePort: 9090
+  - host: [[ALERTMANAGER_HOSTNAME]]
+    http:
+      paths:
+      - backend:
+          serviceName: oidc-proxy
+          servicePort: 80
+      - path: /-/healthy
+        backend:
+          serviceName: kube-prometheus-alertmanager
+          servicePort: 9093
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oidc-proxy
+  name: oidc-proxy
+  namespace: monitoring
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    k8s-app: oidc-proxy
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: oidc-proxy
+  name: oidc-proxy
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oidc-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: oidc-proxy
+    spec:
+      containers:
+      - name: oidc-proxy
+        env:
+        - name: OID_SESSION_NAME
+          value: oidc_proxy
+        - name: OID_DISCOVERY
+          value: https://[[AUTH0_TENANT_NAME]].eu.auth0.com/.well-known/openid-configuration
+        - name: OID_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: monitoring-oidc
+              key: client-id
+        - name: OID_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: monitoring-oidc
+              key: client-secret
+        - name: OID_SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: monitoring-oidc
+              key: cookie-secret
+        image: evry/oidc-proxy:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/openresty/nginx/conf/sites/
+        - name: auth-script
+          mountPath: /usr/local/openresty/nginx/lua
+      volumes:
+      - name: config
+        configMap:
+          name: oidc-proxy-config
+      - name: auth-script
+        configMap:
+          name: oidc-proxy-auth-script


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/161

Adds example configuration for an OIDC proxy and updates the relevant documentation accordingly.
It's based on the work from https://github.com/ministryofjustice/cloud-platform-environments/pull/40