### PR TITLE
Add Kube DNS alert and recovery documentation

### DIFF
--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -50,3 +50,11 @@ spec:
       annotations:
         description: '{{ $labels.instance }} has high memory usage for than 5 minutes.'
         summary: Instance {{ $labels.instance }} memory has critically high usage
+    - alert: KubeDNSDown
+      expr: absent(up{job="kube-dns"} == 1)
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: Prometheus could not scrape kube-dns
+        summary: kube-dns is down

--- a/runbook/KubeDNS-Down.md
+++ b/runbook/KubeDNS-Down.md
@@ -1,0 +1,27 @@
+# KubeDNS-Down
+
+## Alarm
+```
+KubeDNS-Down
+```
+
+## Observation
+Run the following command to confirm kube-dns is in the cluster:
+`$ kubectl get deployments -n kube-system`
+`$ kubectl get pods -n kube-system`
+
+You are looking for the `kube-dns` deployment and pod. 
+
+## Action
+
+If `kube-dns` pod(s) are present but failing, check the logs:
+`$ kubectl exec -it kube-dns -n kube-system sh` 
+
+If the `kube-dns` pod(s) are missing, check to see if the `kube-dns` deployment is present. If the deployment is missing, apply the `kube-dns` [deployment template](https://github.com/kubernetes/kops/blob/release-1.9/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template) to the kube-system namespace.
+
+Before applying, replace all templated syntax from the file with the cluster information.
+
+`$ kubectl apply -f k8s-1.6.yaml.template -n kube-system`
+
+**Note**: The template is for Kops 1.9.
+

--- a/runbook/KubeDNS-Down.md
+++ b/runbook/KubeDNS-Down.md
@@ -2,12 +2,14 @@
 
 ## Alarm
 ```
-KubeDNS-Down
+KubeDNS-Down 
 ```
 
 ## Observation
 Run the following command to confirm kube-dns is in the cluster:
+
 `$ kubectl get deployments -n kube-system`
+
 `$ kubectl get pods -n kube-system`
 
 You are looking for the `kube-dns` deployment and pod. 
@@ -15,6 +17,7 @@ You are looking for the `kube-dns` deployment and pod.
 ## Action
 
 If `kube-dns` pod(s) are present but failing, check the logs:
+
 `$ kubectl exec -it kube-dns -n kube-system sh` 
 
 If the `kube-dns` pod(s) are missing, check to see if the `kube-dns` deployment is present. If the deployment is missing, apply the `kube-dns` [deployment template](https://github.com/kubernetes/kops/blob/release-1.9/upup/models/cloudup/resources/addons/kube-dns.addons.k8s.io/k8s-1.6.yaml.template) to the kube-system namespace.


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#253

**WHAT**
- KubeDNS alert added to Prometheus. If the job "kube-dns" is not up for 5 minutes, then critically alert.
- Documentation on what to do if the kube-dns alarm goes off.

**WHY**
- "kube-dns" is a crucial component to a cluster functioning correctly. If failing, it will impact the DNS performance on the cluster 

https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/