### PR TITLE
Add External DNS alert and recovery documentation

### DIFF
--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -58,3 +58,11 @@ spec:
       annotations:
         description: Prometheus could not scrape kube-dns
         summary: kube-dns is down
+    - alert: External-DNSDown
+      expr: kube_deployment_status_replicas_available{deployment="external-dns"} == 0
+      for: 10s
+      labels:
+        severity: warning
+      annotations:
+        description: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
+        summary: external-dns is down

--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -60,7 +60,7 @@ spec:
         summary: kube-dns is down
     - alert: External-DNSDown
       expr: kube_deployment_status_replicas_available{deployment="external-dns"} == 0
-      for: 10s
+      for: 5m
       labels:
         severity: warning
       annotations:

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -208,6 +208,3 @@ $ helm install -n external-dns --namespace kube-system stable/external-dns -f ./
 Check to see if the external-dns pod is running in the `kube-system` namespace:
 
 `$ kubectl get pods -n kube-system`
-
-
-

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -167,7 +167,7 @@ Before applying, replace all templated syntax from the file with the cluster inf
 External-DNSDown 
 Severity: warning
 ```
-This alert is triggered when 0 external-dns pods are running for longer than 5 minutes
+This alert is triggered when '0' external-dns pods are running for longer than 5 minutes.
 
 Expression:
 ```

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -159,3 +159,55 @@ Before applying, replace all templated syntax from the file with the cluster inf
 `$ kubectl apply -f k8s-1.6.yaml.template -n kube-system`
 
 **Note**: The template is for Kops 1.9.
+
+## External-DNSDown
+
+## Alarm
+```
+External-DNSDown 
+Severity: warning
+```
+This alert is triggered when 0 external-dns pods are running for longer than 5 minutes
+
+Expression:
+```
+kube_deployment_status_replicas_available{deployment="external-dns"} == 0
+for: 5m
+```
+## Action
+
+Check if the external-dns pod is running. If so, describe the pod to check events and check the logs:
+
+```
+$ kubectl get pods -n kube-system
+$ kubectl describe pod <external-dns-container> -n kube-system
+$ kubectl logs <external-dns-container> -n kube-system
+```
+
+If the external-dns is not present, check the helm deployment status to see if all of the resources are running:
+
+`$ helm status external-dns`
+
+If a resource is not running, either upgrade the helm deployment with the external-dns helm chart or delete the current helm deployment and reinstall:
+
+```
+$ git clone git@github.com:ministryofjustice/kubernetes-investigations.git
+$ cd kubernetes-investigations
+$ helm upgrade external-dns ./cluster-components/external-dns/<cluster-name>-helm-values.yaml --namespace kube-system
+```
+
+or
+
+```
+$ git clone git@github.com:ministryofjustice/kubernetes-investigations.git
+$ cd kubernetes-investigations
+$ helm delete --purge external-dns
+$ helm install -n external-dns --namespace kube-system stable/external-dns -f ./cluster-components/external-dns/<cluster-name>-raz-helm-values.yaml
+```
+
+Check to see if the external-dns pod is running in the `kube-system` namespace:
+
+`$ kubectl get pods -n kube-system`
+
+
+


### PR DESCRIPTION
connects to  ministryofjustice/cloud-platform#252

**WHAT**
- External DNS alert added to Prometheus. If the "external-dns" deployment replicas are equal to "0" for longer than 5 minutes, alert a warning.
- Documentation on what to do if the external-dns alarm goes off.

**WHY**
- External DNS is a component that is required to create a Route53 record pointing to the cluster's wildcard hostname. i.e.  "*.apps.cloud-platform-live-0.k8s.integration.dsd.io". Once the record has been created, External DNS has no other purpose in the cluster. Hence the reason, it has been set as a warning. However, this is still an important component in the cluster and should be deployed again if down.
