### PR TITLE
add not ready alert for nodes 

### DIFF
--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -66,11 +66,3 @@ spec:
       annotations:
         description: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
         summary: external-dns is down
-    - alert: K8SNodeNotReady5mins
-      expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-      for: 5m
-      labels:
-        severity: warning
-      annotations:
-        description: The Kubelet on {{ $labels.node }} has not checked in with the API, or has set itself to NotReady, for more than 5 mins
-        summary: Node status is NotReady

--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -66,3 +66,11 @@ spec:
       annotations:
         description: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
         summary: external-dns is down
+    - alert: K8SNodeNotReady5mins
+      expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: The Kubelet on {{ $labels.node }} has not checked in with the API, or has set itself to NotReady, for more than 5 mins
+        summary: Node status is NotReady

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -208,3 +208,36 @@ $ helm install -n external-dns --namespace kube-system stable/external-dns -f ./
 Check to see if the external-dns pod is running in the `kube-system` namespace:
 
 `$ kubectl get pods -n kube-system`
+
+## Node Not Ready Status
+
+## Alarm
+```
+K8SNodeNotReady5mins 
+Severity: warning
+```
+This alert is triggered when kubelet has not checked in with the API or has set itself to NotReady for more then 5 mins
+
+Expression:
+```
+expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+for: 5m
+```
+
+## Action
+
+Run the following command to confirm which node has been set to NotReady:
+
+`$ kubectl get nodes`
+
+`$ kubectl describe node <node_name>`
+
+Look at the 'Conditions' Section for possible more info on 'NotReady' Status
+
+If everything looks ok, you will need to SSH into the node and look at ``kubelet`` logs and look out for errors such as certificate, authentication, connection etc
+
+You can run the following to see kubelet logs
+```
+$ journalctl -u kubelet
+```
+If all else fails, you can terminte the node from the AWS console and let autoscaling group bring up a new one. However, this will most likely cause any information of why the node failed to be deleted with the node.

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -209,7 +209,7 @@ Check to see if the external-dns pod is running in the `kube-system` namespace:
 
 `$ kubectl get pods -n kube-system`
 
-## Node Not Ready Status
+## Node 'Not Ready' Status
 
 ## Alarm
 ```
@@ -241,3 +241,5 @@ You can run the following to see kubelet logs
 $ journalctl -u kubelet
 ```
 If all else fails, you can terminte the node from the AWS console and let autoscaling group bring up a new one. However, this will most likely cause any information of why the node failed to be deleted with the node.
+
+Related Alerts: ``K8SNodeNotReady`` and ``K8SManyNodesNotReady``

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -209,19 +209,19 @@ Check to see if the external-dns pod is running in the `kube-system` namespace:
 
 `$ kubectl get pods -n kube-system`
 
-## Node 'Not Ready' Status
+## Node Status - 'Not Ready'
 
 ## Alarm
 ```
-K8SNodeNotReady5mins 
+K8SNodeNotReady 
 Severity: warning
 ```
-This alert is triggered when kubelet has not checked in with the API or has set itself to NotReady for more then 5 mins
+This alert is triggered when kubelet has not checked in with the API or has set itself to ``NotReady`` for more then 1 hour
 
 Expression:
 ```
 expr: kube_node_status_condition{condition="Ready",status="true"} == 0
-for: 5m
+for: 1h
 ```
 
 ## Action
@@ -242,4 +242,4 @@ $ journalctl -u kubelet
 ```
 If all else fails, you can terminte the node from the AWS console and let autoscaling group bring up a new one. However, this will most likely cause any information of why the node failed to be deleted with the node.
 
-Related Alerts: ``K8SNodeNotReady`` and ``K8SManyNodesNotReady``
+Related Alert: ``K8SManyNodesNotReady``


### PR DESCRIPTION
WHAT
An alert for when a 'Node' Status changes from 'Ready' to 'NotReady'

WHY
This alert would notify a warning as a precursor to a possible bigger problem with the cluster. Documentation on how to look at logs and possible ways to resolve / create new node. 