### PR TITLE
Persistent storage addition to Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ To install kube-prometheus, run:
 $ helm install coreos/kube-prometheus --name kube-prometheus --set global.rbacEnable=true --namespace monitoring -f ./monitoring/helm/kube-prometheus/values.yaml
 ```
 
+### Persistent Volumes with Kube-Prometheus
+To maintain data across deployments and version upgrades, the data must be persisted to a volume (AWS EBS) other than emptyDir, allowing it to be reused by pods after upgrade. 
+Please see the following documentation by CoreOS on how to do this. 
+https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
+
+This has previously been achieved by applying an individual storage class manifest and referencing it in the values.yaml kube-prometheus Helm chart. 
+
 ## Installing AlertManager
 > The Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of deduplicating, grouping, and routing   them to the correct receiver integration such as email or PagerDuty. It also takes care of silencing and inhibition of alerts -
 > [https://prometheus.io/docs/alerting/alertmanager/](https://prometheus.io/docs/alerting/alertmanager/)

--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -165,11 +165,11 @@ alertmanager:
   storageSpec:
     volumeClaimTemplate:
       spec:
-        storageClassName: gluster
+        storageClassName: persistent-storage
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 50Gi
+            storage: 20Gi
       selector: {}
 
 prometheus:

--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -162,15 +162,15 @@ alertmanager:
   ## Alertmanager StorageSpec for persistent data
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
   ##
-  storageSpec: {}
-  #  volumeClaimTemplate:
-  #    spec:
-  #      storageClassName: gluster
-  #      accessModes: ["ReadWriteOnce"]
-  #      resources:
-  #        requests:
-  #          storage: 50Gi
-  #    selector: {}
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: gluster
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 50Gi
+      selector: {}
 
 prometheus:
   ## Alertmanagers to which alerts will be sent
@@ -437,15 +437,15 @@ prometheus:
   ## Prometheus StorageSpec for persistent data
   ## Ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
   ##
-  storageSpec: {}
-  #  volumeClaimTemplate:
-  #    spec:
-  #      storageClassName: gluster
-  #      accessModes: ["ReadWriteOnce"]
-  #      resources:
-  #        requests:
-  #          storage: 50Gi
-  #    selector: {}
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: persistent-storage
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi
+      selector: {}
 
 # default rules are in templates/general.rules.yaml
 # prometheusRules: {}


### PR DESCRIPTION
Connects to https://github.com/ministryofjustice/cloud-platform/issues/312

**WHAT**
To maintain data across deployments and version upgrades, the data must be persisted to some volume other than emptyDir, allowing it to be reused by Pods after an upgrade. This PR allows the creation of an EBS volume along with documentation. 

**WHY**
To complete https://github.com/ministryofjustice/cloud-platform/issues/312