### PR TITLE
Increased retention.

### DIFF
--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -264,7 +264,7 @@ prometheus:
 
   ## How long to retain metrics
   ##
-  retention: 24h
+  retention: 30d
 
   ## Prefix used to register routes, overriding externalUrl route.
   ## Useful for proxies that rewrite URLs.
@@ -431,7 +431,7 @@ prometheus:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 20Gi
+            storage: 100Gi
       selector: {}
 
 # default rules are in templates/general.rules.yaml


### PR DESCRIPTION
With the current 24h retention:
```
/prometheus $ df -h /prometheus
Filesystem                Size      Used Available Use% Mounted on
/dev/xvdbj               19.6G      1.5G     17.0G   8% /prometheus
```
Therefore increasing the disk size accordingly (this might not apply automatically, I don't recall if PV resizing has been merged, in which case I'll intervene to apply manually)