### PR TITLE
Add Prometheus Alerts for curator cronjob

### DIFF
--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -98,3 +98,27 @@ spec:
       annotations:
         description: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}'
         summary: Instance {{ $labels.instance }} root volume utilisation usage is critically high
+    - alert: CuratorCronJobFailure
+      expr: kube_job_status_failed{job=~"elasticsearch-curator-cronjob.+"} > 0
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        description: Job {{$labels.namespaces}}/{{$labels.job}} failed to complete
+        summary: Curtaor cronjob failed
+    - alert: CuratorCronJobRunning
+      expr: time() - kube_cronjob_next_schedule_time {cronjob="elasticsearch-curator-cronjob"} > 3600
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        description: Curator CronJob {{$labels.namespaces}}/{{$labels.cronjob}} is taking more than 1h to complete
+        summary: Curtaor cronjob did not complete after 1h
+    - alert: CuratorJobCompletion
+      expr: kube_job_spec_completions - kube_job_status_succeeded {job=~"elasticsearch-curator-cronjob.+"} > 0
+      for: 1h
+      labels:
+        severity: warning
+      annotations:
+        description: Job completion is taking more than 1h to complete cronjob {{$labels.namespaces}}/{{$labels.job}}
+        summary: Job {{$labels.job}} didn't finish to complete after 1h

--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -105,7 +105,7 @@ spec:
         severity: warning
       annotations:
         description: Job {{$labels.namespaces}}/{{$labels.job}} failed to complete
-        summary: Curtaor cronjob failed
+        summary: Curator cronjob failed
     - alert: CuratorCronJobRunning
       expr: time() - kube_cronjob_next_schedule_time {cronjob="elasticsearch-curator-cronjob"} > 3600
       for: 1h
@@ -113,9 +113,9 @@ spec:
         severity: warning
       annotations:
         description: Curator CronJob {{$labels.namespaces}}/{{$labels.cronjob}} is taking more than 1h to complete
-        summary: Curtaor cronjob did not complete after 1h
+        summary: Curator cronjob did not complete after 1h
     - alert: CuratorJobCompletion
-      expr: kube_job_spec_completions - kube_job_status_succeeded {job=~"elasticsearch-curator-cronjob.+"} > 0
+      expr: kube_job_spec_completions {job=~"elasticsearch-curator-cronjob.+"} - kube_job_status_succeeded {job=~"elasticsearch-curator-cronjob.+"} > 0
       for: 1h
       labels:
         severity: warning

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -402,4 +402,88 @@ sudo find / -type f -size +100M -exec ls -lh {} \;
 
 If the file system needs resizing, please follow the [offical AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html) to expand the volume
 
+## Curator Cronjob Failure
+
+## Alarm
+```
+CuratorCronjobFailure
+Severity: warning
+```
+
+This alert is triggered when the curator cronjob fails.
+
+Expression:
+```
+kube_job_status_failed{job=~"elasticsearch-curator-cronjob.+"} > 0
+for: 1h
+```
+
+## Action
+
+Check why the curator cronjob is failing:
+
+```
+$ kubectl get cronjobs -n logging
+$ kubectl describe cronjob <cronjob-name> -n logging
+$ kubectl logs <cronjob-name> -n logging
+```
+
+The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Curator Cronjob Running
+
+## Alarm
+```
+CuratorCronJobRunning
+Severity: warning
+```
+
+This alert is triggered when the curator cronjob is running longer then 1 hour
+
+Expression:
+```
+time() - kube_cronjob_next_schedule_time {cronjob="elasticsearch-curator-cronjob"} > 3600
+for: 1h
+```
+
+## Action
+
+Check why the curator cronjob is running for over 1 hour:
+
+```
+$ kubectl get cronjobs -n logging
+$ kubectl describe cronjob <cronjob-name> -n logging
+$ kubectl logs <cronjob-name> -n logging
+```
+
+The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
+## Curator Job Completion
+
+## Alarm
+```
+CuratorjobCompletion
+Severity: warning
+```
+
+This alert is triggered when job completion is taking longer then 1 hour to complete curator cronjob
+
+Expression:
+```
+kube_job_spec_completions - kube_job_status_succeeded {job=~"elasticsearch-curator-cronjob.+"} > 0      
+for: 1h
+```
+
+## Action
+
+Check why the job completion for curator cronjob is running for over 1 hour:
+
+```
+$ kubectl get cronjobs -n logging
+$ kubectl describe cronjob <cronjob-name> -n logging
+$ kubectl logs <cronjob-name> -n logging
+```
+
+The following links have more information on [Kubernetes Cronjobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) and [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/)
+
 

--- a/runbook/Custom-Alerts.md
+++ b/runbook/Custom-Alerts.md
@@ -462,7 +462,7 @@ The following links have more information on [Kubernetes Cronjobs](https://kuber
 
 ## Alarm
 ```
-CuratorjobCompletion
+CuratorJobCompletion
 Severity: warning
 ```
 


### PR DESCRIPTION
WHAT
Add prometheus alerts for curator cronjob which runs every day at 1am

3 Alerts have been added-
Curator Cronjob failure
Curator Cronjob Running for over an hour
Job Completion for Curator Cronjob taking longer than an hour

WHY
CP team need to know if the cronjob fails or is not running correctly otherwise we will have disc space issues (which is also monitored) with old logs not being deleted. 