### PR TITLE
Add Alert Manager and Prometheus hostname to kube-prometheus external-url 

### DIFF
--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -57,7 +57,7 @@ alertmanager:
 
   ## External URL at which Alertmanager will be reachable
   ##
-  externalUrl: ""
+  externalUrl: "https://alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io"
 
   ## Alertmanager container image
   ##
@@ -192,7 +192,7 @@ prometheus:
 
   ## External URL at which Prometheus will be reachable
   ##
-  externalUrl: "https://alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+  externalUrl: "https://www.prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io/"
 
   ## Prometheus container image
   ##

--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -192,7 +192,7 @@ prometheus:
 
   ## External URL at which Prometheus will be reachable
   ##
-  externalUrl: ""
+  externalUrl: "https://alertmanager.apps.cloud-platform-live-0.k8s.integration.dsd.io"
 
   ## Prometheus container image
   ##

--- a/monitoring/helm/kube-prometheus/values.yaml
+++ b/monitoring/helm/kube-prometheus/values.yaml
@@ -192,7 +192,7 @@ prometheus:
 
   ## External URL at which Prometheus will be reachable
   ##
-  externalUrl: "https://www.prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io/"
+  externalUrl: "https://www.prometheus.apps.cloud-platform-live-0.k8s.integration.dsd.io"
 
   ## Prometheus container image
   ##


### PR DESCRIPTION
connects to ministryofjustice/cloud-platform#239

**WHAT**
- Add alertmanager external-url to `kube-prometheus` helm values

**WHY**
The value populates the `--web.external-url` argument on the `prometheus-kube-prometheus-0` pod. This replaces the default of `http://kube-prometheus-alertmanager.monitoring:9093/#/alerts`