### PR TITLE
add monitoring load balancer 5xx alerts

### DIFF
--- a/custom-alerts/custom-alerts.yaml
+++ b/custom-alerts/custom-alerts.yaml
@@ -122,3 +122,12 @@ spec:
       annotations:
         description: Job completion is taking more than 1h to complete cronjob {{$labels.namespaces}}/{{$labels.job}}
         summary: Job {{$labels.job}} didn't finish to complete after 1h
+    - alert: LoadBalancer5XXCountHigh
+      expr: count by (service) (increase(http_requests_total{code=~"5.*"}[15m]))  >=  10
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        description: HTTPCode_Target_5XX_Count high for `{{$labels.service}}`
+        summary: HTTPCode_Target_5XX_Count high
+


### PR DESCRIPTION
Why:
ticket https://waffle.io/ministryofjustice/cloud-platform/cards/5bbde2bf82d18e006f282625:
Background:
One of the issues we investigated whilst performing the Chaos engineering tests was that we had a number of 5xx errors on the nginx-controller logs but no alert.

Task:
Look at how we can set up a triggered alert using our current monitoring stack for:
if we receive > 10 5xx errors in 15 minutes
then trigger a warning in Prometheus/AlertManager.